### PR TITLE
Load visibility observer through prop

### DIFF
--- a/src/components/IdealImage/index.js
+++ b/src/components/IdealImage/index.js
@@ -1,6 +1,5 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import Waypoint from 'react-waypoint'
 import Media from '../Media'
 import {icons, loadStates} from '../constants'
 import {xhrLoader, imageLoader, timeout, combineCancel} from '../loaders'
@@ -158,6 +157,8 @@ export default class IdealImage extends Component {
         lqip: PropTypes.string.isRequired,
       }),
     ]).isRequired,
+    /** react component to determine visibility */
+    VisibilityObserver: PropTypes.node.isRequired,
   }
 
   static defaultProps = {
@@ -328,10 +329,11 @@ export default class IdealImage extends Component {
   }
 
   render() {
+    const {VisibilityObserver} = this.props
     const icon = this.props.getIcon(this.state)
     const message = this.props.getMessage(icon, this.state)
     return (
-      <Waypoint onEnter={this.onEnter} onLeave={this.onLeave}>
+      <VisibilityObserver onEnter={this.onEnter} onLeave={this.onLeave}>
         <Media
           {...this.props}
           {...fallbackParams(this.props)}
@@ -341,7 +343,7 @@ export default class IdealImage extends Component {
           onDimensions={dimensions => this.setState({dimensions})}
           message={message}
         />
-      </Waypoint>
+      </VisibilityObserver>
     )
   }
 }

--- a/src/components/IdealImageWithDefaults/index.js
+++ b/src/components/IdealImageWithDefaults/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Waypoint from 'react-waypoint'
 import IdealImage from '../IdealImage'
 import icons from '../icons'
 import theme from '../theme'
@@ -7,6 +8,7 @@ const IdealImageWithDefaults = props => <IdealImage {...props} />
 
 IdealImageWithDefaults.defaultProps = {
   ...IdealImage.defaultProps,
+  VisibilityObserver: Waypoint,
   icons,
   theme,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Allow user to supply a VisibilityObserver property to replace React-Waypoint

<!-- Why are these changes necessary? -->

**Why**: Different people need different things out of the visibility observer

<!-- How were these changes implemented? -->

**How**: Add VisibilityObserver prop to IdealImage, and set Waypoint as the default in IdealImageWithDefaults

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
~~* [ ] Tests~~ No testing set up
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
