### PR TITLE
Allow custom optional visibility observer

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -72,6 +72,17 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "GeKorm",
+      "name": "George Kormaris",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/6104345?v=4",
+      "profile": "http://www.gekorm.com",
+      "contributions": [
+        "code",
+        "doc",
+        "ideas"
+      ]
     }
   ],
   "repoType": "github"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![downloads][downloads-badge]][npmtrends]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Code of Conduct][coc-badge]][coc]
 
@@ -48,6 +48,8 @@ Read the [introduction](introduction.md).
   - [theme](#theme)
   - [threshold](#threshold)
   - [width](#width)
+  - [observer](#observer)
+  - [children](#children)
 - [Other Solutions](#other-solutions)
 - [Contributors](#contributors)
 - [LICENSE](#license)
@@ -73,6 +75,7 @@ Example for create-react-app (you need v2 for macros) based project
 ```js
 import React from 'react'
 import lqip from 'lqip.macro'
+import Waypoint from 'react-waypoint'
 import IdealImage from 'react-ideal-image'
 
 import image from './images/doggo.jpg'
@@ -85,6 +88,7 @@ const App = () => (
     alt="doggo"
     width={3500}
     height={2095}
+    observer={Waypoint}
   />
 )
 ```
@@ -217,6 +221,33 @@ Tells how much to wait in milliseconds until consider the download to be slow.
 
 Width of the image in px.
 
+### observer
+
+> `function({onEnter, onLeave, children})` | optional
+
+A visibility observer component, like react-waypoint, used for lazy-loading.
+
+### children
+
+> `function({onEnter, onLeave, children}) | React.Element` | optional
+
+Observer, used instead of the `observer` prop. Can either be a render prop or a React element
+
+```js
+<IdealImage
+    placeholder={{lqip}}
+    srcSet={[{src: image, width: 3500}]}
+    alt="doggo"
+    width={3500}
+    height={2095}
+    observer={Waypoint}
+>
+  <Waypoint scrollableAncestor="window" /> // onEnter and onLeave are passed automatically
+</IdealImage>
+```
+
+If neither `observer` nor `children` is passed, the image will be treated as visible in the viewport
+
 ## Other Solutions
 
 - [react-progressive-image](https://github.com/FormidableLabs/react-progressive-image)
@@ -239,7 +270,7 @@ Thanks goes to these people ([emoji key][emojis]):
 <!-- prettier-ignore -->
 | [<img src="https://avatars3.githubusercontent.com/u/179534?s=460&v=4" width="100px;"/><br /><sub><b>stereobooster</b></sub>](https://github.com/stereobooster)<br />[💻](https://github.com/stereobooster/react-ideal-image/commits?author=stereobooster "Code") [📖](https://github.com/stereobooster/react-ideal-image/commits?author=stereobooster "Documentation") [🚇](#infra-stereobooster "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/stereobooster/react-ideal-image/commits?author=stereobooster "Tests") | [<img src="https://avatars1.githubusercontent.com/u/498274?s=460&v=4" width="100px;"/><br /><sub><b>Ivan Babak</b></sub>](https://github.com/sompylasar)<br />[📖](https://github.com/stereobooster/react-ideal-image/commits?author=sompylasar "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/4299398?s=460&v=4" width="100px;"/><br /><sub><b>Arun Kumar</b></sub>](https://github.com/palerdot)<br />[📖](https://github.com/stereobooster/react-ideal-image/commits?author=palerdot "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/1192452?v=4" width="100px;"/><br /><sub><b>Andrew Lisowski</b></sub>](http://hipstersmoothie.com)<br />[💻](https://github.com/stereobooster/react-ideal-image/commits?author=hipstersmoothie "Code") | [<img src="https://avatars1.githubusercontent.com/u/3386714?v=4" width="100px;"/><br /><sub><b>Timothy Vernon</b></sub>](https://github.com/tvthatsme)<br />[⚠️](https://github.com/stereobooster/react-ideal-image/commits?author=tvthatsme "Tests") | [<img src="https://avatars0.githubusercontent.com/u/5151881?v=4" width="100px;"/><br /><sub><b>vishalShinde</b></sub>](http://vs1682.github.io)<br />[📖](https://github.com/stereobooster/react-ideal-image/commits?author=vs1682 "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/5207796?v=4" width="100px;"/><br /><sub><b>Evgeniy Kumachev</b></sub>](https://github.com/EvgeniyKumachev)<br />[📖](https://github.com/stereobooster/react-ideal-image/commits?author=EvgeniyKumachev "Documentation") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-
+| [<img src="https://avatars3.githubusercontent.com/u/6104345?v=4" width="100px;"/><br /><sub><b>George Kormaris</b></sub>](http://www.gekorm.com)<br />[💻](https://github.com/stereobooster/react-ideal-image/commits?author=GeKorm "Code") [📖](https://github.com/stereobooster/react-ideal-image/commits?author=GeKorm "Documentation") [🤔](#ideas-GeKorm "Ideas, Planning, & Feedback") |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:  
This PR allows users to

1. Omit lazy-loading completely, no need for additional dependencies
2. Provide any visibility observer

<!-- Why are these changes necessary? -->

**Why**:  
The main thing this PR achieves isn't much different than #51 I would say the only differences are:

1. It's easier to omit the observer (no need to provide a mock for onEnter to make all images visible)
2. It provides a few additional ways of defining an observer, especially because it seems many people like the child render prop pattern
3. It fixes a potential bug in onEnter

<!-- How were these changes implemented? -->

**How**:
Depending on what the user provides, in order:

- props.observer -> same as #51
- props.children as a function -> same as props.observer
- props.children as a React element -> element is cloned and extra props onEnter and onLeave are applied
- none of the above -> render the image without lazy loading (onEnter as soon as possible)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests  | **Nope, wanted to discuss first**
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Please feel free to check the published fork `npm install @gekorm/react-ideal-image`